### PR TITLE
Add GitHub Actions CI to project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: "CI"
+
+on:
+  push:
+    branches-ignore:
+      - "main"
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: osspackrat_test
+          POSTGRES_USER: osspackrat
+          POSTGRES_DB: osspackrat_test
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install system dependencies
+        run: apt install libpq-dev
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+        env:
+          DB_HOST: postgres
+          DB_USER: osspackrat
+          DB_PASSWORD: osspackrat_test
+          DB_NAME: osspackrat_test

--- a/oss_packrat/orm/database.py
+++ b/oss_packrat/orm/database.py
@@ -4,10 +4,10 @@ import psycopg2
 import psycopg2.extras
 import os
 
-user = os.getenv("PSQL_USER")
-password = os.getenv("PSQL_PASSWORD")
+user = os.getenv("DB_USER")
+password = os.getenv("DB_PASSWORD")
 host = os.getenv("DB_HOST")
-port = "5432"
+port = os.getenv('DB_PORT', "5432")
 
 
 class Connection:
@@ -34,8 +34,8 @@ class Connection:
         Please note, this class assumes that you have the following
         environment variables set:
 
-        PSQL_USER     : The user of your postgres instance
-        PSQL_PASSWORD : The postgres user's password
+        DB_USER       : The user of your postgres instance
+        DB_PASSWORD   : The postgres user's password
         DB_HOST       : The host name of your database
 
         If these are not set, no connection will be established.

--- a/tests/orm/test_database.py
+++ b/tests/orm/test_database.py
@@ -4,7 +4,7 @@ from oss_packrat.orm import database
 
 
 class TestDatabase:
-    test_db_name = "osspackrat_test"
+    test_db_name = os.getenv("DB_NAME", "osspackrat_test")
     test_error_log = "test_db_error_log.csv"
     connection = database.Connection(test_db_name, test_error_log)
     q = database.Query(connection)


### PR DESCRIPTION
# Overview

This PR adds CI to the project using GitHub Actions.

# Implementation

Using the [relevant GitHub Actions documentation](https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers), this PR introduces a GitHub action that:

1. Runs every time there is a Push to any branch _other_ than `main`
2. Sets up a `service` container named `postgres` containing a postgresql database
3. Attempts to run Pytest using the repository's code in every version of python specified in the CI.yaml file (currently just `3.10`, but others can be added whenever you'd like

Additionally, I updated the naming scheme in the codebase to be slightly more consistent (i.e. instead of some ENV vars starting with `DB_` and some starting with `PSQL_`, they now all start with `DB_`) and also ensured that the name of the test database is pulled from the environment with the old value as a default in case it's not defined.

# Testing

GitHub Actions currently don't have a testing framework.

Closes #9 